### PR TITLE
Docker base image to mcr image

### DIFF
--- a/database-mssql/docker/Dockerfile
+++ b/database-mssql/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/mssql-server-linux:latest
+FROM mcr.microsoft.com/mssql/server:2017-CU24-ubuntu-16.04
 
 # Create app directory
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Microsoft moved sql server images  from docker hub to it's own mcr registry.
So no more docker images are available.

![mcr-movement](https://user-images.githubusercontent.com/29627753/123796453-c3055280-d902-11eb-9905-93df6f258852.png)

