### PR TITLE
Fix update job error: Throttle violation

### DIFF
--- a/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
+++ b/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
@@ -3,7 +3,8 @@ kind: CronJob
 metadata:
   name: update-bot-job
 spec:
-  schedule: "*/2 * * * *"     #change it to your schedule
+  # Update intervall for new questions and answers
+  schedule: "*/30 * * * *"     #change it to your schedule
   concurrencyPolicy: Replace
   jobTemplate:
     spec:
@@ -83,6 +84,7 @@ kind: CronJob
 metadata:
   name: update-all-bot-job
 spec:
+  # update intervall for refreshing all questions
   schedule: "0 23 * * *"     #change it to your schedule
   concurrencyPolicy: Replace
   jobTemplate:

--- a/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
+++ b/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
@@ -75,3 +75,85 @@ spec:
                   secretKeyRef:
                     name: bot-secret
                     key: db-password
+              - name: UPDATE_ALL
+                value: "N"
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: update-all-bot-job
+spec:
+  schedule: "0 23 * * *"     #change it to your schedule
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: update-bot-container
+            image: gabbi/bot-update      #change it to your image
+            imagePullPolicy: Always
+            env:
+              - name: CAI_CREDENTIALS_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: cai-credentials-url
+              - name: CAI_CREDENTIALS_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: cai-credentials-id
+              - name: CAI_CREDENTIALS_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: cai-credentials-secret
+              - name: BOT_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: bot-url
+              - name: X_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: cai-x-token
+              - name: STACK_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: stack-url
+              - name: STACK_TAG
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: stack-tag
+              - name: STACK_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: stack-key
+              - name: DB_NAME
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: db-name
+              - name: DB_HOST
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: db-host
+              - name: DB_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: db-username
+              - name: DB_PW
+                valueFrom:
+                  secretKeyRef:
+                    name: bot-secret
+                    key: db-password
+              - name: UPDATE_ALL
+                value: "Y"


### PR DESCRIPTION
Fix for #191  

# Short description of changes
## update-bot.js
- The update job checks if the environment variable `UPDATE_ALL` has the value `"Y"`. 
- If `UPDATE_ALL` is set to `"Y"` the behaviour is the same as before
- Else:
  - For each question check if the question is in the database (and therefore was answered)
  - Only if the question is **not** in the database but has an answer, the answers are requested and added to the database

## cronjob.yaml
- Environment variable `UPDATE_ALL` was added to cronjob `update-bot-job`
- Second cronjob `update-all-bot-job` was created (copy of `update-bot-job` with these modifications:
  - This cronjob runs only once per day
  - `UPDATE_ALL="Y"`
  - `restartPolicy` was set to `Never` to avoid a behaviour similar to #191 (crashing and due to restarts creating too many requests). Since there should be notifications when there is an issue (#195), there is no need to restart this job (from my point of view).