### PR TITLE
Fix for #212 updatebot fails

### DIFF
--- a/chatbot-conversational_AI/bot-observer-tool/app/server.js
+++ b/chatbot-conversational_AI/bot-observer-tool/app/server.js
@@ -123,20 +123,21 @@ app.get('/stack', async (req, res) => {
 
 async function stack_request(url, config) {
   try {
-    console.log(`${new Date()}: STACK_REQUEST: ${url}`);
+    console.log(`${new Date().toISOString()}: STACK_REQUEST: ${url}`);
     const result = await got(url, config);
     // application must wait some seconds if backoff-field in response is set
     // otherwise a throttle-violation is raised
     if ("backoff" in result.body) {
       var backoff_seconds = result.body["backoff"];
-      console.log(`${new Date()}: Backoff response received from Stack! Duration: ${backoff_seconds} seconds`);
+      console.log(`${new Date().toISOString()}: Backoff response received from Stack! Duration: ${backoff_seconds} seconds`);
       // add some offset (500ms) to be sure that the backoff is long enough
-      await new Promise(r => setTimeout(r, backoff_seconds * 1000 + 500));
-      console.log(`${new Date()}: Backoff finsihed!`);
+      // the stack server does not measure the time differences very accurately (and not in favor of the client)
+      await new Promise(r => setTimeout(r, (backoff_seconds+2) * 1000));
+      console.log(`${new Date().toISOString()}: Backoff finsihed!`);
     }
     return result;
   } catch(err) {
-    console.log(`${new Date()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
+    console.log(`${new Date().toISOString()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
     throw err;
   }
 }

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -37,18 +37,18 @@ async function main() {
 
     // If (question is not in database but answered) or all questions should be updated
     if ((q_in_db_flag == 0 && stackQuestion.is_answered) || update_all_questions) {
-      var answers = await get_stackAnswers(stackQuestion.question_id),
-        questionText = stackQuestion.title;
-      questionLink = stackQuestion.link;
-      var bestAnswer = answers.items[0],
-        answerText = bestAnswer.body;
+      var answers = await get_stackAnswers(stackQuestion.question_id);
+      var questionText = stackQuestion.title;
+      var questionLink = stackQuestion.link;
+      var bestAnswer = answers.items[0];
+      var answerText = bestAnswer.body;
 
-      var stack_q_id = stackQuestion.question_id,
-        stack_q_ts = stackQuestion.last_activity_date
-      stack_a_id = bestAnswer.answer_id,
-        stack_a_ts = bestAnswer.last_edit_date ? bestAnswer.last_edit_date : bestAnswer.creation_date
-      cai_q_id = null,
-        cai_a_id = null;
+      var stack_q_id = stackQuestion.question_id;
+      var stack_q_ts = stackQuestion.last_activity_date;
+      var stack_a_id = bestAnswer.answer_id;
+      var stack_a_ts = bestAnswer.last_edit_date ? bestAnswer.last_edit_date : bestAnswer.creation_date;
+      var cai_q_id = null;
+      var cai_a_id = null;
 
 
       // Question is already in the database and needs to be updated (tested on 20210910)

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -37,7 +37,7 @@ async function main() {
     }
 
     // If (question is not in database but answered) or all questions should be updated
-    if ((q_in_db_flag == 0 && stackQuestion.is_answered) || update_all_questions) {
+    if ((q_in_db_flag == 0 && stackQuestion.is_answered) || (update_all_questions && stackQuestion.is_answered)) {
       var answers = await get_stackAnswers(stackQuestion.question_id);
       var questionText = stackQuestion.title;
       var questionLink = stackQuestion.link;

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -17,6 +17,7 @@ async function main() {
   for (let counter = 0; counter < stackData.items.length; counter++) {
     // Choose the next question from Stack
     stackQuestion = stackData.items[counter];
+    var stack_q_id = stackQuestion.question_id;
 
     // Check if the question is already in the database
     var q_in_db_flag = 0;
@@ -43,7 +44,6 @@ async function main() {
       var bestAnswer = answers.items[0];
       var answerText = bestAnswer.body;
 
-      var stack_q_id = stackQuestion.question_id;
       var stack_q_ts = stackQuestion.last_activity_date;
       var stack_a_id = bestAnswer.answer_id;
       var stack_a_ts = bestAnswer.last_edit_date ? bestAnswer.last_edit_date : bestAnswer.creation_date;

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -68,7 +68,7 @@ async function main() {
       // Question is not in database or must be updated (was deleted and must be added again)
       if (q_in_db_flag == 0 || q_update_flag == 1) {
         try {
-          console.log(`Add answer to CAI (${answerText})`);
+          console.log(`Add answer to CAI (${answerText.substring(0, 50)})`);
           var arrTuple = await add_caiAnswer(answerText, questionLink, caiCredentials.access_token);
           var caiAnswerResult = arrTuple[0];
           var errValue = arrTuple[1];
@@ -238,6 +238,7 @@ async function add_caiAnswer(answerText, questionLink, access_token) {
     return [JSON.parse(result.body), null];
   } catch (err) {
     console.log("An Error has occurred during adding an answer to SAP CAI: " + err);
+    console.log(`cai_request_url=${cai_request_url}; finalAnswerString=${finalAnswerString}`);
     //throw err;
     return [null, err];
   }

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -30,10 +30,10 @@ async function main() {
       }
     }
     if (q_in_db_flag == 1) {
-      console.log(`${new Date()}: Question (ID=${stack_q_id}) was found in mssql db at index ${id_in_db}`);
+      console.log(`${new Date().toISOString()}: Question (ID=${stack_q_id}) was found in mssql db at index ${id_in_db}`);
     }
     else {
-      console.log(`${new Date()}: Question (ID=${stack_q_id}) was not found in mssql db.`);
+      console.log(`${new Date().toISOString()}: Question (ID=${stack_q_id}) was not found in mssql db.`);
     }
 
     // If (question is not in database but answered) or all questions should be updated
@@ -54,13 +54,13 @@ async function main() {
       // Question is already in the database and needs to be updated (tested on 20210910)
       var q_update_flag = 0;
       if (q_in_db_flag == 1 && (dbData[id_in_db].stack_q_ts != stack_q_ts || dbData[id_in_db].stack_a_ts != stack_a_ts)) {
-        console.log(`${new Date()}: Deleting Question (ID=${dbData[id_in_db].id_num}) from CAI and mssql, because it is already in the dbs but was updated (or received new answer).`);
+        console.log(`${new Date().toISOString()}: Deleting Question (ID=${dbData[id_in_db].id_num}) from CAI and mssql, because it is already in the dbs but was updated (or received new answer).`);
         try { // Delete it from the database and CAI
           await delete_caiEntry(dbData[id_in_db].cai_a_id, caiCredentials.access_token);
           await db_request.query(`delete from Questions where id_num = '${dbData[id_in_db].id_num}'; `);
           q_update_flag = 1;
         } catch (err) {
-          console.log(`${new Date()}: An Error has occurred during deleting a Question/Answer pair (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) in SAP CAI and the internal DB`);
+          console.log(`${new Date().toISOString()}: An Error has occurred during deleting a Question/Answer pair (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) in SAP CAI and the internal DB`);
           throw err;
         }
       }
@@ -68,21 +68,21 @@ async function main() {
       // Question is not in database or must be updated (was deleted and must be added again)
       if (q_in_db_flag == 0 || q_update_flag == 1) {
         try {
-          console.log(`${new Date()}: Add answer to CAI (${answerText.substring(0, 50)})`);
+          console.log(`${new Date().toISOString()}: Add answer to CAI (${answerText.substring(0, 50)})`);
           var arrTuple = await add_caiAnswer(answerText, questionLink, caiCredentials.access_token);
           var caiAnswerResult = arrTuple[0];
           var errValue = arrTuple[1];
           console.log("Answer from CAI: " + caiAnswerResult);
           if (errValue === null) {
             cai_a_id = caiAnswerResult.results.id;
-            console.log(`${new Date()}: Add question (for answer ID=${cai_a_id}) to CAI (${questionText})`);
+            console.log(`${new Date().toISOString()}: Add question (for answer ID=${cai_a_id}) to CAI (${questionText})`);
             var caiQuestionResult = await add_caiQuestion(questionText, cai_a_id, caiCredentials.access_token);
             cai_q_id = caiQuestionResult.results.id;
             console.log("Insert entry in mssql: stack_q_id=${stack_q_id}, stack_a_id=${stack_a_id}, cai_q_id=${cai_q_id}, cai_a_id=${cai_a_id}");
             await db_request.query(`insert into Questions (stack_q_id, stack_q_ts, stack_a_id, stack_a_ts, cai_q_id, cai_a_id) values ('${stack_q_id}', '${stack_q_ts}', '${stack_a_id}', '${stack_a_ts}', '${cai_q_id}', '${cai_a_id}'); select * from Questions where stack_q_id = '${stack_q_id}'`);
           }
         } catch (err) {
-          console.log(`${new Date()}: An Error has occurred during adding a new Question/Answer pair to SAP CAI and the internal DB`);
+          console.log(`${new Date().toISOString()}: An Error has occurred during adding a new Question/Answer pair to SAP CAI and the internal DB`);
           throw err;
         }
       }
@@ -93,15 +93,15 @@ async function main() {
         await delete_caiEntry(dbData[id_in_db].cai_a_id, caiCredentials.access_token);
         await db_request.query(`delete from Questions where id_num = '${dbData[id_in_db].id_num}'`);
       } catch (err) {
-        console.log(`${new Date()}: An Error has occurred during deleting a Question/Answer pair (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) in SAP CAI and the internal DB (it was deleted because it was deleted in Stack Overflow)`);
+        console.log(`${new Date().toISOString()}: An Error has occurred during deleting a Question/Answer pair (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) in SAP CAI and the internal DB (it was deleted because it was deleted in Stack Overflow)`);
         throw err;
       }
-      console.log(`${new Date()}: A question (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) was deleted from Stack Overflow and hence in the bot.`);
+      console.log(`${new Date().toISOString()}: A question (CAI_ANSWER_ID=${dbData[id_in_db].cai_a_id}; MSSQL_ID=${dbData[id_in_db].id_num}) was deleted from Stack Overflow and hence in the bot.`);
     }
   }
 
   await sqlconnection.close();
-  console.log(`${new Date()}: done`);
+  console.log(`${new Date().toISOString()}: done`);
   process.exit(0);
 }
 
@@ -132,7 +132,7 @@ async function get_stackQuestions() {
 
     return allQuestions;
   } catch (err) {
-    console.log(`${new Date()}: An Error has occurred during requesting the stack questions labeled with ${process.env.STACK_TAG}. Maybe it is a problem with concatenating multiple pages of questions because max pagesize exceeded.`);
+    console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack questions labeled with ${process.env.STACK_TAG}. Maybe it is a problem with concatenating multiple pages of questions because max pagesize exceeded.`);
     throw err;
   }
 }
@@ -143,27 +143,28 @@ async function get_stackAnswers(question_id) {
     const result = await stack_request(stack_url_answers, stack_config);
     return result.body;
   } catch (err) {
-    console.log(`${new Date()}: An Error has occurred during requesting the stack answer to question ${question_id}`);
+    console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack answer to question ${question_id}`);
     throw err;
   }
 }
 
 async function stack_request(url, config) {
   try {
-    console.log(`${new Date()}: STACK_REQUEST: ${url}`);
+    console.log(`${new Date().toISOString()}: STACK_REQUEST: ${url}`);
     const result = await got(url, config);
     // application must wait some seconds if backoff-field in response is set
     // otherwise a throttle-violation is raised
     if ("backoff" in result.body) {
       var backoff_seconds = result.body["backoff"];
-      console.log(`${new Date()}: Backoff response received from Stack! Duration: ${backoff_seconds} seconds`);
-      // add some offset (500ms) to be sure that the backoff is long enough
-      await new Promise(r => setTimeout(r, backoff_seconds * 1000 + 500));
-      console.log(`${new Date()}: Backoff finsihed!`);
+      console.log(`${new Date().toISOString()}: Backoff response received from Stack! Duration: ${backoff_seconds} seconds`);
+      // add some offset (2 seconds) to be sure that the backoff is long enough.
+      // the stack server does not measure the time differences very accurately (and not in favor of the client)
+      await new Promise(r => setTimeout(r, (backoff_seconds+2) * 1000));
+      console.log(`${new Date().toISOString()}: Backoff finsihed!`);
     }
     return result;
   } catch(err) {
-    console.log(`${new Date()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
+    console.log(`${new Date().toISOString()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
     throw err;
   }
 }

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -224,7 +224,8 @@ async function add_caiAnswer(answerText, questionLink, access_token) {
 
     // add the Link to Stack Overflow to the Answer
     if (slackFormat.length > 1800) { // answer is too long
-      finalFormat = "\n" + slackFormat.substring(0, slackFormat.split('. ', 4).join('. ').length + 1) + " ... " + " <" + questionLink + "/|[See more]>";
+      // cut the answer to max four sentences and max 1800 characters
+      finalFormat = "\n" + slackFormat.substring(0, Math.min(slackFormat.split('. ', 4).join('. ').length + 1, 1800)) + " ... " + " <" + questionLink + "/|[See more]>";
     } else {
       var finalFormat = "\n" + slackFormat + "\n\n" + "For more help, please click <" + questionLink + "/|here> to go directly to this question on Stack Overflow.";
     }

--- a/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
+++ b/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
@@ -87,7 +87,7 @@ metadata:
   name: update-all-bot-job
 spec:
   # update intervall for refreshing all questions
-  schedule: "0 23 * * *"     #change it to your schedule
+  schedule: "15 23 * * *"     #change it to your schedule
   concurrencyPolicy: Replace
   jobTemplate:
     spec:


### PR DESCRIPTION
Fix for #212 

## Changes in code
- Improved logging of update-bot
  - Add multiple messages for better debugging
- Unified and improved variable declaration
  - Eliminate inconsistent syntax and avoided accidental creation of global variables
- Append missing variable declaration bug caused by #191 
  - `stack_id` was undefined in first loop execution and therefore lead to the repeated addition described in #212 
- Fix bug of exceeding maximum length of CAI entries:
  - CAI entries should not be longer than 1,800 characters. To deal with this, answers longer than 1,800 characters were cut down to their first four sentences. In (at least) one case with very long sentences due to bullet points the length of these four sentences exceeded the limit of 1,800. 
  - The new behaviour extends the previous preprocessing of answers by limiting the output of the current preprocessing to 1,800 characters. 
- Fix small bug from #191 
  - In the update-all behavior, an attempt was made to include in the databases even those questions for which there are no answers. For the CAI that is not possible by the current approach and additionally there would be little to no benefit in doing it. Therefore this was changed to only add questions with at least one answer (which is the intended behaviour).

## Manual operations to restore database consistency
- Deleted one entry in mssql database, which was pointing to a non-existing CAI answer ID
- Deleted all answers in CAI, that do not have a corresponding mssql entry
- Commands for both operations will be added to the internal wiki

In contrast to #191 the code of this pull request is already tested. This branch was selected in the CI/CD pipeline and thus executed in the cluster. 
Please review this pull request anyway and add comments if something is unclear.