### PR TITLE
Add regcred to mssql deployment

### DIFF
--- a/chatbot-conversational_AI/knowledge-database/database-mssql/k8s/deployment.yaml
+++ b/chatbot-conversational_AI/knowledge-database/database-mssql/k8s/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           volumeMounts:
             - name: mssqldb
               mountPath: /var/opt/mssql
+      imagePullSecrets:
+        - name: regcred
       volumes:
         - name: mssqldb
           persistentVolumeClaim:


### PR DESCRIPTION
# Add secret to db deployment

Adding the registry secret to the deployment file of the mssql database to allow pulling of images from the private Docker registry.