### PR TITLE
Alert notifications for update bot

### DIFF
--- a/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
+++ b/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
@@ -83,14 +83,64 @@ spec:
       }
     }
 
+    /*
+    data should be a JSON object.
+    There is the possiblity to set these keys:
+    - severity: ["fatal", "info", "notice", "warning", "error"]
+    - category: ["alert", "exception", "notification", "warning"]
+    - email_header: string
+    - details: JSON object
+    */
     async function processAlert(client, data){
         const cur_time = Math.floor(+new Date() / 1000);
+        var severity_value = Severity.FATAL;
+        switch(data.severity) {
+          case "fatal":
+            severity_value = Severity.FATAL;
+            break;
+          case "info":
+            severity_value = Severity.INFO;
+            break;
+          case "notice":
+            severity_value = Severity.NOTICE;
+            break;
+          case "warning":
+            severity_value = Severity.WARNING;
+            break;
+          case "error":
+            severity_value = Severity.ERROR;
+            break;
+          default:
+            console.log("Unexpected value for severity in processAlert: " + data.severity);
+        }
+
+        var category_value = Category.ALERT;
+        switch(data.category) {
+          case "alert":
+            category_value = Category.ALERT;
+            break;
+          case "info":
+            category_value = Category.EXCEPTION;
+            break;
+          case "notice":
+            category_value = Category.NOTIFICATION;
+            break;
+          case "warning":
+            category_value = Category.WARNING;
+            break;
+          default:
+            console.log("Unexpected value for category in processAlert: " + data.category);
+        }
+
+        var email_header = data.email_header || "Message";
+        var details = data.details || data;
+
         return await client.sendEvent({
-            body: 'The chatbot crashed. \nDETAILS:' + JSON.stringify(data).replace(/[{}]|,/g, "\n"),
-            subject: 'Chatbot crash',
+            body: 'The chatbot reported a ' + severity_value + ' ' + category_value '. \nDETAILS:' + JSON.stringify(details).replace(/[{}]|,/g, "\n"),
+            subject: 'Chatbot ' + category_value + ': ' + email_header,
             eventType: 'system_down_condition',
-            severity: Severity.FATAL,
-            category: Category.ALERT,
+            severity: severity_value,
+            category: category_value,
             eventTimestamp: cur_time,
             priority: 1
         });

--- a/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
+++ b/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
@@ -83,15 +83,15 @@ spec:
       }
     }
 
-    /*
-    data should be a JSON object.
-    There is the possiblity to set these keys:
-    - severity: ["fatal", "info", "notice", "warning", "error"]
-    - category: ["alert", "exception", "notification", "warning"]
-    - email_header: string
-    - details: JSON object
-    */
+    // data should be a JSON object.
+    // There is the possiblity to set these keys:
+    // - severity: ["fatal", "info", "notice", "warning", "error"]
+    // - category: ["alert", "exception", "notification", "warning"]
+    // - email_header: string
+    // - details: JSON object
+
     async function processAlert(client, data){
+        console.log("processAlert() data: " + JSON.stringify(data));
         const cur_time = Math.floor(+new Date() / 1000);
         var severity_value = Severity.FATAL;
         switch(data.severity) {
@@ -136,11 +136,19 @@ spec:
         var details = data.details || data;
 
         return await client.sendEvent({
-            body: 'The chatbot reported a ' + severity_value + ' ' + category_value '. \nDETAILS:' + JSON.stringify(details).replace(/[{}]|,/g, "\n"),
+            body: 'The chatbot reported a ' + severity_value + ' ' + category_value + '. \nDETAILS: ' + JSON.stringify(details).replace(/[{}]|,/g, "\n"),
             subject: 'Chatbot ' + category_value + ': ' + email_header,
             eventType: 'system_down_condition',
             severity: severity_value,
             category: category_value,
+            resource: {
+                resourceName: 'update-bot',
+                resourceType: 'deployment',
+                resourceInstance: '1',
+                tags: {
+                    detailsLink: 'https://grafana.' + process.env.CLUSTER_DOMAIN + '/explore?orgId=1&left=%5B%22now-1h%22,%22now%22,%22Loki%22,%7B%22expr%22:%22%7Bnamespace%3D%5C%22cap%5C%22%7D%22%7D,%7B%7D%5D'
+                }
+            },
             eventTimestamp: cur_time,
             priority: 1
         });

--- a/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
+++ b/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: services.cloud.sap.com/v1
+kind: ServiceInstance
+metadata:
+  name: alert-notif-ser-instance
+spec:
+  serviceOfferingName: alert-notification
+  servicePlanName: standard
+  parameters:
+    configuration:
+      actions:
+      - name: email
+        properties:
+          destination: {{ .Values.alertnotification.email | b64dec }}
+        state: ENABLED
+        type: EMAIL
+      conditions:
+      - name: system_down_condition
+        predicate: EQUALS
+        propertyKey: eventType
+        propertyValue: system_down_condition
+      subscriptions:
+      - actions:
+        - email
+        conditions:
+        - system_down_condition
+        name: system_down_condition
+        state: ENABLED
+---
+apiVersion: serverless.kyma-project.io/v1alpha1
+kind: Function
+metadata:
+  name: alert-notif
+spec:
+  env:
+  - name: oauth_url
+    valueFrom:
+      secretKeyRef:
+        key: oauth_url
+        name: alert-notif-ser-binding
+  - name: client_id
+    valueFrom:
+      secretKeyRef:
+        key: client_id
+        name: alert-notif-ser-binding
+  - name: client_secret
+    valueFrom:
+      secretKeyRef:
+        key: client_secret
+        name: alert-notif-ser-binding
+  - name: CLUSTER_DOMAIN
+    value: {{ .Values.alertnotification.clusterdomain | b64dec }}
+  - name: url
+    value: {{ .Values.alertnotification.url | b64dec }}
+  deps: "{ \n  \"name\": \"alert-notif-test\",\n  \"version\": \"1.0.0\",\n  \"dependencies\":
+    {\n    \"@sap_oss/alert-notification-client\": \"1.1.0\"\n  }\n}"
+  runtime: nodejs14
+  source: >-
+    const { OAuthAuthentication, AlertNotificationClient, BasicAuthentication,
+        RegionUtils, Severity, Category } = require("@sap_oss/alert-notification-client");
+    const { Region, Platform } =
+    require("@sap_oss/alert-notification-client/dist/utils/region");
+
+
+    const oAuthAuthentication = new OAuthAuthentication({
+        username: process.env.client_id,
+        password: process.env.client_secret,
+        oAuthTokenUrl: process.env.oauth_url
+    });
+
+    module.exports = {
+      main: async function (event, context) {
+          try{
+            const client = new AlertNotificationClient({
+                authentication: oAuthAuthentication,
+                region: new Region(Platform.CF, process.env.url),
+            });
+            const result =  await processAlert(client, event.data);
+            return JSON.stringify(result);
+          }catch(error){
+              console.log(error);
+              return error;
+          };
+      }
+    }
+
+    async function processAlert(client, data){
+        const cur_time = Math.floor(+new Date() / 1000);
+        return await client.sendEvent({
+            body: 'The chatbot crashed. \nDETAILS:' + JSON.stringify(data).replace(/[{}]|,/g, "\n"),
+            subject: 'Chatbot crash',
+            eventType: 'system_down_condition',
+            severity: Severity.FATAL,
+            category: Category.ALERT,
+            eventTimestamp: cur_time,
+            priority: 1
+        });
+    }
+
+
+
+---
+apiVersion: services.cloud.sap.com/v1
+kind: ServiceBinding
+metadata:
+  name: alert-notif-ser-binding
+spec:
+  serviceInstanceName: alert-notif-ser-instance

--- a/chatbot-conversational_AI/update-bot/app/package.json
+++ b/chatbot-conversational_AI/update-bot/app/package.json
@@ -6,11 +6,12 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node update-bot.js && exit"
   },
-  "author": "Lasse Urban",
+  "author": "Lasse Urban, Alexander Weers, Jano Hanzlik, Cansu Doganay",
   "license": "ISC",
   "dependencies": {
     "mssql": "7.2.0",
     "got": "9.6.0",
-    "turndown": "7.1.1"
+    "turndown": "7.1.1",
+    "axios": "^0.22.0"
   }
 }

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -115,7 +115,7 @@ async function main() {
  *  Alert Notification function                         *
  ********************************************************/
 
-function sendAlert(details, subject="", severity="", category="") {
+async function sendAlert(details, subject="", severity="", category="") {
   var data = {
     email_header: subject,
     severity: severity,
@@ -123,7 +123,7 @@ function sendAlert(details, subject="", severity="", category="") {
     details: details
   };
   console.log("Send alert: " + JSON.stringify(data));
-  axios.post(ALERT_NOTIF_SRV, data, {})
+  await axios.post(ALERT_NOTIF_SRV, data, {})
     .then(() => {
       console.log("--------Submitted error event to Alert Notification--------");
     })
@@ -159,7 +159,7 @@ async function get_stackQuestions() {
     return allQuestions;
   } catch (err) {
     console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack questions labeled with ${process.env.STACK_TAG}. Maybe it is a problem with concatenating multiple pages of questions because max pagesize exceeded.`);
-    sendAlert(err, "Failed in get_stackQuestions");
+    await sendAlert(err, "Failed in get_stackQuestions");
     throw err;
   }
 }
@@ -171,7 +171,7 @@ async function get_stackAnswers(question_id) {
     return result.body;
   } catch (err) {
     console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack answer to question ${question_id}`);
-    sendAlert(err, "Failed to get_stackAnswers");
+    await sendAlert(err, "Failed to get_stackAnswers");
     throw err;
   }
 }
@@ -193,7 +193,7 @@ async function stack_request(url, config) {
     return result;
   } catch(err) {
     console.log(`${new Date().toISOString()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
-    sendAlert(err, "Failed to stack_request");
+    await sendAlert(err, "Failed to stack_request");
     throw err;
   }
 }
@@ -218,7 +218,7 @@ async function get_dbData(db_request) {
     return result.recordsets[0];
   } catch (err) {
     console.log("An Error has occurred during requesting the database content");
-    sendAlert(err, "Failed to get_dbData");
+    await sendAlert(err, "Failed to get_dbData");
     throw err;
   }
 }
@@ -245,7 +245,7 @@ async function get_caiCredentials() {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during requesting the cai credentials");
-    sendAlert(err, "Failed to get_caiCredentials");
+    await sendAlert(err, "Failed to get_caiCredentials");
     throw err;
   }
 }
@@ -292,7 +292,7 @@ async function add_caiAnswer(answerText, questionLink, access_token) {
   } catch (err) {
     console.log("An Error has occurred during adding an answer to SAP CAI: " + err);
     console.log(`cai_request_url=${cai_request_url}; finalAnswerString=${finalAnswerString}`);
-    sendAlert(err, "Failed to add_caiAnswer");
+    await sendAlert(err, "Failed to add_caiAnswer");
     //throw err;
     return [null, err];
   }
@@ -310,7 +310,7 @@ async function add_caiQuestion(questionText, answerID, access_token) {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during adding a question to SAP CAI");
-    sendAlert(err, "Failed to add_caiQuestion");
+    await sendAlert(err, "Failed to add_caiQuestion");
     throw err;
   }
 }
@@ -323,7 +323,7 @@ async function delete_caiEntry(answerID, access_token) {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during deleting a question from SAP CAI");
-    sendAlert("Failed to delete_caiEntry");
+    await sendAlert("Failed to delete_caiEntry");
     throw err;
   }
 }
@@ -372,7 +372,7 @@ async function get_all_CAI_indices(access_token) {
   }
   catch (err) {
     console.log("An Error has occurred during requesting answer indices from SAP CAI");
-    sendAlert(err, "Failed to get_all_CAI_indices");
+    await sendAlert(err, "Failed to get_all_CAI_indices");
     throw err;
   }
 

--- a/chatbot-conversational_AI/update-bot/app/update-bot.js
+++ b/chatbot-conversational_AI/update-bot/app/update-bot.js
@@ -1,6 +1,9 @@
 const sql = require('mssql');
 const got = require('got');
+const axios = require("axios");
 const TurndownService = require('turndown');
+
+const ALERT_NOTIF_SRV = "http://alert-notif.karl-kyma.svc.cluster.local";
 
 async function main() {
   var sqlconnection = await sql.connect(database_config);
@@ -108,6 +111,26 @@ async function main() {
   process.exit(0);
 }
 
+/********************************************************
+ *  Alert Notification function                         *
+ ********************************************************/
+
+function sendAlert(details, subject="", severity="", category="") {
+  var data = {
+    email_header: subject,
+    severity: severity,
+    category: category,
+    details: details
+  };
+  console.log("Send alert: " + JSON.stringify(data));
+  axios.post(ALERT_NOTIF_SRV, data, {})
+    .then(() => {
+      console.log("--------Submitted error event to Alert Notification--------");
+    })
+    .catch((error) => {
+      console.log("--------a sendAlert error occurred-------- ", error.message);
+    });
+}
 
 
 /********************************************************
@@ -136,6 +159,7 @@ async function get_stackQuestions() {
     return allQuestions;
   } catch (err) {
     console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack questions labeled with ${process.env.STACK_TAG}. Maybe it is a problem with concatenating multiple pages of questions because max pagesize exceeded.`);
+    sendAlert(err, "Failed in get_stackQuestions");
     throw err;
   }
 }
@@ -147,6 +171,7 @@ async function get_stackAnswers(question_id) {
     return result.body;
   } catch (err) {
     console.log(`${new Date().toISOString()}: An Error has occurred during requesting the stack answer to question ${question_id}`);
+    sendAlert(err, "Failed to get_stackAnswers");
     throw err;
   }
 }
@@ -168,6 +193,7 @@ async function stack_request(url, config) {
     return result;
   } catch(err) {
     console.log(`${new Date().toISOString()}: Error in stack_request!\nURL: ${url}\nError: ${err}`);
+    sendAlert(err, "Failed to stack_request");
     throw err;
   }
 }
@@ -192,6 +218,7 @@ async function get_dbData(db_request) {
     return result.recordsets[0];
   } catch (err) {
     console.log("An Error has occurred during requesting the database content");
+    sendAlert(err, "Failed to get_dbData");
     throw err;
   }
 }
@@ -218,6 +245,7 @@ async function get_caiCredentials() {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during requesting the cai credentials");
+    sendAlert(err, "Failed to get_caiCredentials");
     throw err;
   }
 }
@@ -264,6 +292,7 @@ async function add_caiAnswer(answerText, questionLink, access_token) {
   } catch (err) {
     console.log("An Error has occurred during adding an answer to SAP CAI: " + err);
     console.log(`cai_request_url=${cai_request_url}; finalAnswerString=${finalAnswerString}`);
+    sendAlert(err, "Failed to add_caiAnswer");
     //throw err;
     return [null, err];
   }
@@ -281,6 +310,7 @@ async function add_caiQuestion(questionText, answerID, access_token) {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during adding a question to SAP CAI");
+    sendAlert(err, "Failed to add_caiQuestion");
     throw err;
   }
 }
@@ -293,6 +323,7 @@ async function delete_caiEntry(answerID, access_token) {
     return JSON.parse(result.body);
   } catch (err) {
     console.log("An Error has occurred during deleting a question from SAP CAI");
+    sendAlert("Failed to delete_caiEntry");
     throw err;
   }
 }
@@ -341,6 +372,7 @@ async function get_all_CAI_indices(access_token) {
   }
   catch (err) {
     console.log("An Error has occurred during requesting answer indices from SAP CAI");
+    sendAlert(err, "Failed to get_all_CAI_indices");
     throw err;
   }
 

--- a/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
+++ b/chatbot-conversational_AI/update-bot/k8s/cronjob.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       template:
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           containers:
           - name: update-bot-container
             image: <image-name> #gabbi/bot-update      #change it to your image


### PR DESCRIPTION
# Integrate alert notifications into update bot
Fixes #195 

## Goal
- receive emails in case of failure during update routine
- use [SAP BTP alert notification](https://help.sap.com/docs/ALERT_NOTIFICATION) for that

## Overview of changes
- add alert notification deployment file (already prepared for HELM values)
- extend functionality of simple alert notification examples to change email header, alert severity and category
- add async/await functionality to sendAlert and axios call to finish request before program is ended in catch blocks
- call alert notification function from catch blocks inside update bot
- update required packages for update bot
- update authors of update bot
- change restartPolicy of update-bot to `never` to avoid unnecessary restarts and emails

## Possible extensions
- Use [slack messages instead of emails](https://help.sap.com/docs/ALERT_NOTIFICATION/5967a369d4b74f7a9c2b91f5df8e6ab6/88a4774f9d3f43259b4dc9e7e7729829.html)

The functionality was tested and works as desired. Please review the changes and approve or comment. 