### PR TITLE
Change alert notifications to slack

### DIFF
--- a/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
+++ b/chatbot-conversational_AI/alert-notif/k8s/deployment.yaml
@@ -13,6 +13,11 @@ spec:
           destination: {{ .Values.alertnotification.email | b64dec }}
         state: ENABLED
         type: EMAIL
+      - name: slack
+        properties:
+          destination: {{ .Values.alertnotification.slack.webhook | b64dec }}
+        state: ENABLED
+        type: SLACK
       conditions:
       - name: system_down_condition
         predicate: EQUALS
@@ -20,7 +25,7 @@ spec:
         propertyValue: system_down_condition
       subscriptions:
       - actions:
-        - email
+        - slack
         conditions:
         - system_down_condition
         name: system_down_condition


### PR DESCRIPTION
# Change alert notifications from email to slack
Fix #233 

## Overview of changes
- Add new `action` of type `SLACK`. This action can be used to send messages to a slack channel via webhook. To set up Slack, see [this](https://help.sap.com/docs/ALERT_NOTIFICATION/5967a369d4b74f7a9c2b91f5df8e6ab6/88a4774f9d3f43259b4dc9e7e7729829.html?locale=en-US#slack-action) instructions
- Already prepared for helm values
- Still kept email configuration to allow for simple switching between email and slack messages (just change line 28 in the new file)

The functionality was tested and works as desired. Please review the changes and approve or comment. 